### PR TITLE
Implement GithubClient and add loading of repositories and files for players

### DIFF
--- a/api-server/models.py
+++ b/api-server/models.py
@@ -1,5 +1,12 @@
 from tortoise import fields, models
+from tortoise.transactions import in_transaction
 from enum import Enum
+from datetime import datetime
+from uuid import uuid4
+from services.github_client import GithubClient, GithubRepositoryFileLoadingError
+import logging
+
+logger = logging.getLogger()
 
 
 class Session(models.Model):
@@ -8,7 +15,7 @@ class Session(models.Model):
         LOBBY = "lobby"
 
     id = fields.CharField(max_length=20, pk=True)
-    state = fields.CharEnumField(State, null=False, required=True, max_length=20)
+    state = fields.CharEnumField(State, max_length=20)
     created_at = fields.DatetimeField(auto_now_add=True)
 
     # nullable, stores the host player's id. Attempting to make this a type of a ForeignKey relation will result in an 'cylical fk reference' error by Tortoise
@@ -17,15 +24,133 @@ class Session(models.Model):
 
 
 class Player(models.Model):
+    MAX_REPOS_TO_GENERATE_FILES = 5
+    SUPPORTED_EXTENSIONS = [
+        "py",
+        "js",
+        "ts",
+        "jsx",
+        "tsx",
+        "go",
+        "dart",
+        "java",
+        "cc",
+        "cpp",
+        "c",
+        "swift",
+    ]
+
     class ConnectionState(str, Enum):
         CONNECTED = "connected"
         DISCONNECTED = "disconnected"
 
+    # id will be of the format "{session_id}-{username}"
     id = fields.CharField(max_length=40, pk=True)
-    username = fields.CharField(max_length=30, null=False, required=True)
-    connection_state = fields.CharEnumField(
-        ConnectionState, null=False, required=True, max_length=20
-    )
+    username = fields.CharField(max_length=30)
+    connection_state = fields.CharEnumField(ConnectionState, max_length=20)
     session: fields.ForeignKeyRelation[Session] = fields.ForeignKeyField(
         "models.Session", "players"
+    )
+
+    # todo(ramko9999): if necessary, add the next_page number to fetch the next set of repos as an db field
+    repos: fields.ReverseRelation["Repository"]
+
+    async def load_repos(self, gh_client: GithubClient):
+        repos, _ = await gh_client.get_non_forked_repos(self.username, min_repos=100)
+
+        repo_models = []
+        for repo in repos:
+            repo_models.append(
+                Repository(
+                    id=uuid4(),
+                    name=repo["name"],
+                    description=repo["description"],
+                    stars=repo["stars"],
+                    language=repo["language"],
+                    default_branch=repo["default_branch"],
+                    url=repo["url"],
+                    last_pushed_at=datetime.fromisoformat(
+                        repo["pushed_at"].replace("Z", "+00:00")
+                    ),
+                    author=self,
+                )
+            )
+
+        await Repository.bulk_create(repo_models)
+        logger.info(
+            f"Found {len(repo_models)} available repos for author {self.username}"
+        )
+
+    async def load_files(self, gh_client: GithubClient):
+        async with in_transaction():
+            repos = await self.repos.filter(load_status=False).order_by(
+                "last_pushed_at"
+            )
+
+            loaded_repo_ids = []
+            repo_index = 0
+            non_empty_repo_count = 0
+            file_models = []
+            while (
+                non_empty_repo_count < self.MAX_REPOS_TO_GENERATE_FILES
+                and repo_index < len(repos)
+            ):
+                repo = repos[repo_index]
+                try:
+                    files = await gh_client.get_files_for_repo(
+                        repo.name,
+                        repo.default_branch,
+                        self.SUPPORTED_EXTENSIONS,
+                    )
+                    for file in files:
+                        file_models.append(
+                            File(
+                                name=file["name"],
+                                path=file["path"],
+                                download_url=file["download_url"],
+                                repo=repo,
+                            )
+                        )
+                    loaded_repo_ids.append(repo.id)
+                    repo_index += 1
+                    if len(files) > 0:
+                        non_empty_repo_count += 1
+                except GithubRepositoryFileLoadingError:
+                    pass
+
+            if len(loaded_repo_ids) > 0:
+                await Repository.filter(id__in=loaded_repo_ids).update(load_status=True)
+            if len(file_models) > 0:
+                await File.bulk_create(file_models)
+            logger.info(
+                f"Extracted {len(file_models)} files from {len(loaded_repo_ids)} repos for author {self.username}"
+            )
+
+
+class Repository(models.Model):
+    id = fields.UUIDField(pk=True)
+
+    load_status = fields.BooleanField(default=False)
+    name = fields.CharField(max_length=100)
+    description = fields.CharField(max_length=500, null=True)
+    stars = fields.IntField()
+    language = fields.CharField(max_length=20, null=True)
+    default_branch = fields.CharField(max_length=100)
+    url = fields.CharField(max_length=200)
+    last_pushed_at = fields.DatetimeField()
+
+    author: fields.ForeignKeyRelation[Session] = fields.ForeignKeyField(
+        "models.Player", "repos"
+    )
+
+
+class File(models.Model):
+    id = fields.UUIDField(pk=True)
+
+    name = fields.CharField(max_length=100)
+    path = fields.CharField(max_length=200)
+    download_url = fields.CharField(max_length=200)
+
+    repo: fields.ForeignKeyRelation[Repository] = fields.ForeignKeyField(
+        "models.Repository", "files"
     )

--- a/api-server/routes/session.py
+++ b/api-server/routes/session.py
@@ -1,10 +1,12 @@
 import logging
 import random
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Depends, status
 from nanoid import generate
 from pydantic import BaseModel
 from tortoise.transactions import in_transaction
 from models import Session, Player
+from services.github_client import GithubClient, GithubUserNotFound
+from config import GITHUB_ACCESS_TOKEN
 
 router = APIRouter(prefix="/session", tags=["Session"])
 logger = logging.getLogger()
@@ -50,19 +52,34 @@ async def get_lobby(session: Session) -> Lobby:
     return Lobby(players=lobby_players)
 
 
-@router.post(
-    "/join/{session_id}", status_code=status.HTTP_202_ACCEPTED, response_model=Lobby
-)
-async def join(session_id: str, join_body: JoinRequestBody):
-    # todo(ramko9999): select for update may prevent insertions of rows which reference session_id via Fkey. Consider passing in no_key
-    # or using an other table just for locking lobby related activities such as joining, leaving or scoring the game.
-    session = await Session.filter(id=session_id).select_for_update().first()
+async def verify_session(session_id: str):
+    session = await Session.get_or_none(id=session_id)
     if not session:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND, f"Session {session_id} not found"
         )
+
+
+def get_gh_client():
+    return GithubClient(GITHUB_ACCESS_TOKEN)
+
+
+@router.post(
+    "/join/{session_id}",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=Lobby,
+    dependencies=[Depends(verify_session)],
+)
+async def join(
+    session_id: str,
+    join_body: JoinRequestBody,
+    gh_client: GithubClient = Depends(get_gh_client),
+):
+    # todo(ramko9999): select for update may prevent insertions of rows which reference session_id via Fkey. Consider passing in no_key
+    # or using an other table just for locking lobby related activities such as joining, leaving or scoring the game.
     player_id = f"{session_id}-{join_body.username}"
     async with in_transaction():
+        session = await Session.filter(id=session_id).select_for_update().first()
         player = await Player.get_or_none(id=player_id)
         if player and player.connection_state == Player.ConnectionState.CONNECTED:
             raise HTTPException(
@@ -81,6 +98,15 @@ async def join(session_id: str, join_body: JoinRequestBody):
                 connection_state=Player.ConnectionState.CONNECTED,
             )
             await player.save()
+            try:
+                await player.load_repos(gh_client)
+            except GithubUserNotFound:
+                raise HTTPException(
+                    status.HTTP_404_NOT_FOUND,
+                    f"Player's username {join_body.username} is not a valid Github username",
+                )
+            await player.load_files(gh_client)
+
         if session.host is None:
             session.host = player.id
             await session.save(update_fields=["host"])
@@ -92,17 +118,15 @@ class LeaveRequestBody(BaseModel):
 
 
 @router.post(
-    "/leave/{session_id}", status_code=status.HTTP_202_ACCEPTED, response_model=Lobby
+    "/leave/{session_id}",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=Lobby,
+    dependencies=[Depends(verify_session)],
 )
 async def leave(session_id: str, leave_body: LeaveRequestBody):
-    session = await Session.filter(id=session_id).select_for_update().first()
-    if not session:
-        # todo(Ramko9999): make this session check a dependency
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, f"Session {session_id} not found"
-        )
     player_id = f"{session_id}-{leave_body.username}"
     async with in_transaction():
+        session = await Session.filter(id=session_id).select_for_update().first()
         player = await Player.get_or_none(id=player_id)
         if not player or player.connection_state == Player.ConnectionState.DISCONNECTED:
             raise HTTPException(

--- a/api-server/services/github_client.py
+++ b/api-server/services/github_client.py
@@ -1,0 +1,139 @@
+import logging
+from typing import TypedDict, Optional
+from httpx import AsyncClient
+from fastapi import status
+from pathlib import Path
+from datetime import datetime
+
+logger = logging.getLogger()
+
+
+class RepositoryDict(TypedDict):
+    name: str
+    pushed_at: str
+    url: str
+    stars: int
+    default_branch: str
+    description: Optional[str]
+    language: Optional[str]
+
+
+class FileDict(TypedDict):
+    name: str
+    path: str
+    download_url: str
+
+
+class RateLimitResult(TypedDict):
+    limit: int
+    used: int
+    reset: datetime
+
+
+class GithubUserNotFound(Exception):
+    pass
+
+
+class GithubRepositoryFileLoadingError(Exception):
+    pass
+
+
+class GithubClient:
+    def __init__(self, access_token: str):
+        self.access_token = access_token
+        self.HEADERS = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/vnd.github+json",
+        }
+
+    async def get_rate_limit(self):
+        endpoint = "https://api.github.com/rate_limit"
+        async with AsyncClient() as client:
+            response = await client.get(endpoint, headers=self.HEADERS)
+            core = response.json()["resources"]["core"]
+            return RateLimitResult(
+                limit=core["limit"],
+                used=core["used"],
+                reset=datetime.fromtimestamp(core["reset"]),
+            )
+
+    async def get_non_forked_repos(
+        self, username: str, min_repos: int = 100, page: int = 1
+    ):
+        endpoint = f"https://api.github.com/users/{username}/repos"
+        repo_dicts: list[RepositoryDict] = []
+        can_get_next_page = True
+        async with AsyncClient() as client:
+            while len(repo_dicts) < min_repos and can_get_next_page:
+                params = {
+                    "type": "owner",
+                    "sort": "pushed",
+                    "direction": "asc",
+                    "per_page": min(min_repos, 100),
+                    "page": page,
+                }
+                response = await client.get(
+                    endpoint, params=params, headers=self.HEADERS
+                )
+                if response.status_code == status.HTTP_404_NOT_FOUND:
+                    raise GithubUserNotFound()
+                for repo in response.json():
+                    if not repo["fork"] and repo["size"] > 0:
+                        repo_dicts.append(
+                            RepositoryDict(
+                                name=repo["full_name"],
+                                pushed_at=repo["pushed_at"],
+                                url=repo["html_url"],
+                                stars=repo["stargazers_count"],
+                                default_branch=repo["default_branch"],
+                                description=repo["description"],
+                                language=repo["language"],
+                            )
+                        )
+
+                can_get_next_page = ("link" in response.headers) and (
+                    'rel="next"' in response.headers["link"]
+                )
+                page += 1
+
+        next_page = None
+        if can_get_next_page:
+            next_page = page
+        return repo_dicts, next_page
+
+    async def get_files_for_repo(
+        self,
+        full_repo_name: str,
+        default_branch: str,
+        supported_extensions: set[str],
+        max_file_size: int = 1000000,
+    ):
+        def get_download_url(file_path: str):
+            return f"https://raw.githubusercontent.com/{full_repo_name}/{default_branch}/{file_path}"
+
+        endpoint = (
+            f"https://api.github.com/repos/{full_repo_name}/git/trees/{default_branch}"
+        )
+
+        params = {"recursive": True}
+        file_dicts: list[FileDict] = []
+        async with AsyncClient() as client:
+            response = await client.get(endpoint, headers=self.HEADERS, params=params)
+            if response.status_code != status.HTTP_200_OK:
+                logger.warn(
+                    f"Unable to load files from {full_repo_name}: {response.json()['message']}"
+                )
+                raise GithubRepositoryFileLoadingError()
+
+            for entity in response.json()["tree"]:
+                if entity["type"] == "blob" and entity["size"] <= max_file_size:
+                    extension = Path(entity["path"]).suffix[1:]
+                    if extension in supported_extensions:
+                        file_dicts.append(
+                            FileDict(
+                                name=Path(entity["path"]).name,
+                                path=entity["path"],
+                                download_url=get_download_url(entity["path"]),
+                            )
+                        )
+        return file_dicts

--- a/api-server/test/conftest.py
+++ b/api-server/test/conftest.py
@@ -3,9 +3,16 @@ from httpx import AsyncClient
 from tortoise import Tortoise
 from config import TEST_DB_URI
 from main import app
-from models import Session, Player
+from typing import Callable
+from models import Session, Player, Repository, File
+from unittest.mock import patch, Mock, AsyncMock
+from services.github_client import (
+    GithubClient,
+    RepositoryDict,
+    FileDict,
+)
 
-MODELS = [Session, Player]
+MODELS = [Session, Player, Repository, File]
 
 
 @pytest.fixture(scope="session")
@@ -27,6 +34,38 @@ async def init_test_db():
 async def api_client():
     async with AsyncClient(app=app, base_url="http://test") as client:
         yield client
+
+
+@pytest.fixture
+def mock_gh_client_factory():
+    mock_gh_client = Mock(spec=GithubClient)
+
+    def factory(
+        user_to_repos: Callable[..., list[RepositoryDict]],
+        repo_to_files: Callable[..., list[FileDict]],
+    ):
+        mock_gh_client.return_value.get_non_forked_repos = AsyncMock(
+            side_effect=user_to_repos
+        )
+
+        mock_gh_client.return_value.get_files_for_repo = AsyncMock(
+            side_effect=repo_to_files
+        )
+        return mock_gh_client
+
+    with patch("routes.session.GithubClient", new=mock_gh_client):
+        yield factory
+
+
+@pytest.fixture
+def empty_gh_client(mock_gh_client_factory):
+    def user_to_repos(*args, **kwargs):
+        return ([], None)
+
+    def repo_to_files(*args, **kwargs):
+        return []
+
+    yield mock_gh_client_factory(user_to_repos, repo_to_files)
 
 
 @pytest.fixture


### PR DESCRIPTION
- Implemented `GithubClient` which serves as a wrapper around the Github REST API for API methods of interest.
- Used the `GithubClient` load files and repositories for players
- Added a CLI method to show Github API usage
- Added a small test to ensure players cannot join with an invalid Github username.