### PR TITLE
Enhance Editor & CommentSider interaction interplay

### DIFF
--- a/api-server/config.py
+++ b/api-server/config.py
@@ -9,9 +9,9 @@ DB_URI = os.environ.get("DB_URI")
 TEST_DB_URI = os.environ.get("TEST_DB_URI")
 GITHUB_CLIENT_ID = os.environ.get("GITHUB_CLIENT_ID")
 GITHUB_CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET")
-GITHUB_ACCESS_TOKEN_ENDPOINT = os.environ.get("GITHUB_ACCESS_TOKEN_ENDPOINT")
-GITHUB_LOGIN_ENDPOINT = os.environ.get("GITHUB_LOGIN_ENDPOINT")
 AUTH_SECRET = os.environ.get("AUTH_SECRET")
+GITHUB_ACCESS_TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token"
+GITHUB_LOGIN_ENDPOINT = "https://github.com/login/oauth/authorize"
 
 """
 Added this bit here to make local testing easy. Run `python main.py -d`

--- a/client/src/components/commentSider/CommentSider.css
+++ b/client/src/components/commentSider/CommentSider.css
@@ -1,103 +1,108 @@
-
 .comments-container-header {
-    font-weight: 500;
+  font-weight: 500;
 }
 
 .filters {
-    display: flex;
-    flex-direction: row;
-    gap: 2rem;
-    font-size: 1.5rem;
+  display: flex;
+  flex-direction: row;
+  gap: 2rem;
+  font-size: 1.5rem;
 }
 
 .filter {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .selected-filter {
-    text-decoration: underline;
-    text-underline-offset: 0.5rem;
+  text-decoration: underline;
+  text-underline-offset: 0.5rem;
 }
 
 .emoji-reactions {
-    border: 0.1rem solid var(--secondary-accent);
-    border-radius: 0.8rem;
-    padding: 0.1rem 0.5rem;
+  border: 0.1rem solid var(--secondary-accent);
+  border-radius: 0.8rem;
+  padding: 0.1rem 0.5rem;
 }
 
 abbr {
-    text-decoration: none;
-    cursor: pointer;
+  text-decoration: none;
+  cursor: pointer;
 }
 
 .comments-container {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    padding-left: 0.5rem;
-    width: 100%;
-    max-width: 100%;
-    max-height: 75vh;
-    overflow-y: scroll;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0 0.5rem;
+  width: 100%;
+  max-width: 100%;
+  max-height: 75vh;
+  overflow-y: scroll;
 }
 
 .comments-container-content {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .comments-section-header {
-    display: flex;
-    flex-direction: row;
-    gap: 0.5rem;
-    align-items: center;
-    font-weight: 500;
-}
-
-.comments-section-header > code {
-    cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  align-items: center;
+  font-weight: 500;
 }
 
 .comments-section-content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .comments-section {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .player-comment {
-    border: 0.1rem solid var(--secondary-accent);
-    border-radius: 0.4rem;
-    padding: 0.4rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    cursor: pointer;
+  position: relative;
+  border: 0.1rem solid var(--secondary-accent);
+  border-radius: 0.4rem;
+  padding: 0.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  cursor: pointer;
+  box-shadow: none;
+}
+
+.player-comment:hover {
+  box-shadow: 0px 0px 5px 1px;
+}
+
+.player-comment-selected {
+  box-shadow: 0px 0px 5px 1px;
 }
 
 .player-comment-header {
-    display: flex;
-    flex-direction: row;
-    gap: 0.2rem;
-    align-items: center;
-    font-family: monospace;
-    font-weight: bold;
+  display: flex;
+  flex-direction: row;
+  gap: 0.2rem;
+  align-items: center;
+  font-family: monospace;
+  font-weight: bold;
 }
 
 .player-comment-avatar {
-    width: 2rem;
-    object-fit: contain;
-    border: 2px solid;
-    border-radius: 50%;
+  width: 2rem;
+  object-fit: contain;
+  border: 2px solid;
+  border-radius: 50%;
 }
 
 .player-comment-content {
-    text-overflow: ellipsis;
-    font-size: 0.9rem;
+  text-overflow: ellipsis;
+  font-size: 0.9rem;
 }

--- a/client/src/components/commentSider/CommentSider.css
+++ b/client/src/components/commentSider/CommentSider.css
@@ -76,14 +76,18 @@ abbr {
   gap: 0.4rem;
   cursor: pointer;
   box-shadow: none;
+  transition-duration: 150ms;
+  font-family: monospace;
 }
 
 .player-comment:hover {
   box-shadow: 0px 0px 5px 1px;
+  transform: translateY(-4px) translateX(-4px);
 }
 
 .player-comment-selected {
   box-shadow: 0px 0px 5px 1px;
+  transform: translateY(-4px) translateX(-4px);
 }
 
 .player-comment-header {
@@ -91,7 +95,6 @@ abbr {
   flex-direction: row;
   gap: 0.2rem;
   align-items: center;
-  font-family: monospace;
   font-weight: bold;
 }
 

--- a/client/src/components/editor/Editor.css
+++ b/client/src/components/editor/Editor.css
@@ -18,6 +18,10 @@
   border-left: solid var(--line-selection-border-color);
 }
 
+.comment-highlighted-line {
+  background-color: rgb(217, 234, 211);
+  border-left: solid rgb(147, 196, 125);
+}
 
 .editor-context-menu {
   position: absolute;

--- a/client/src/components/editor/Styles.tsx
+++ b/client/src/components/editor/Styles.tsx
@@ -2,7 +2,6 @@ import styled from "styled-components";
 
 export const Pre = styled.pre`
   text-align: left;
-  margin: 0;
   padding: 0.5rem;
   margin: 0rem;
   max-height: calc(75vh - 1.4rem);
@@ -13,7 +12,6 @@ export const Pre = styled.pre`
     line-height: 1.3em;
     height: 1.3em;
   }
-  z-index: 0;
 `;
 
 export const Line = styled.div`

--- a/client/src/components/editor/Util.ts
+++ b/client/src/components/editor/Util.ts
@@ -1,0 +1,112 @@
+export interface ViewportBounds {
+  topLeft: {
+    x: number;
+    y: number;
+  };
+  bottomRight: {
+    x: number;
+    y: number;
+  };
+  width: number;
+  height: number;
+}
+
+/*
+todo(Ramko9999): Add tests for the below functions
+*/
+
+export function getViewportBounds(element: HTMLElement): ViewportBounds {
+  const { x, y, width, height } = element.getBoundingClientRect();
+  return {
+    topLeft: { x, y },
+    bottomRight: {
+      x: x + width,
+      y: y + height,
+    },
+    width,
+    height,
+  };
+}
+
+export function anchorViewportBoundsRelativeTo(
+  bounds: ViewportBounds,
+  anchor: ViewportBounds
+): ViewportBounds {
+  return {
+    topLeft: {
+      x: bounds.topLeft.x - anchor.topLeft.x,
+      y: bounds.topLeft.y - anchor.topLeft.y,
+    },
+    bottomRight: {
+      x: bounds.bottomRight.x - anchor.topLeft.x,
+      y: bounds.bottomRight.y - anchor.topLeft.y,
+    },
+    width: bounds.width,
+    height: bounds.height,
+  };
+}
+
+export function mergeViewportBounds(
+  bounds1: ViewportBounds,
+  bounds2: ViewportBounds
+) {
+  const topLeft = {
+    x: Math.min(bounds1.topLeft.x, bounds2.topLeft.x),
+    y: Math.min(bounds1.topLeft.y, bounds2.topLeft.y),
+  };
+
+  const bottomRight = {
+    x: Math.max(bounds1.bottomRight.x, bounds2.bottomRight.x),
+    y: Math.max(bounds1.bottomRight.y, bounds2.bottomRight.y),
+  };
+
+  return {
+    topLeft,
+    bottomRight,
+    width: bottomRight.x - topLeft.x,
+    height: bottomRight.y - topLeft.y,
+  };
+}
+
+/*
+Computes the minimum amount to scroll in the Y axis to display the scrollTarget 
+*/
+export function computeLazyScrollYAxisOptions(
+  currentViewport: ViewportBounds,
+  scrollTarget: ViewportBounds,
+  maxScrollPadding: number
+): ScrollToOptions {
+  const scrollPadding = Math.min(
+    Math.max(Math.floor((currentViewport.height - scrollTarget.height) / 2), 0),
+    maxScrollPadding
+  );
+
+  const desiredViewportYBounds = {
+    start: currentViewport.topLeft.y + scrollPadding,
+    end: currentViewport.bottomRight.y - scrollPadding,
+  };
+
+  const isTargetBoundWithinDesiredView =
+    desiredViewportYBounds.start <= scrollTarget.topLeft.y &&
+    desiredViewportYBounds.end >= scrollTarget.bottomRight.y;
+
+  if (!isTargetBoundWithinDesiredView) {
+    if (
+      scrollTarget.topLeft.y < desiredViewportYBounds.start ||
+      scrollTarget.height >= currentViewport.height
+    ) {
+      return {
+        top: scrollTarget.topLeft.y - desiredViewportYBounds.start,
+        behavior: "smooth",
+      };
+    } else {
+      return {
+        top: scrollTarget.bottomRight.y - desiredViewportYBounds.end,
+        behavior: "smooth",
+      };
+    }
+  }
+
+  // no need to scroll since the scrollTarget is already within our desired viewport Y range
+  return {};
+}

--- a/client/src/components/editor/hooks/lineSelection/UseLineSelection.tsx
+++ b/client/src/components/editor/hooks/lineSelection/UseLineSelection.tsx
@@ -7,7 +7,7 @@ export interface SelectedLines {
 
 interface useLineSelectionResult {
   selectedLines: SelectedLines;
-  setSelectedLines: React.Dispatch<React.SetStateAction<SelectedLines>>;
+  clearLineSelection: () => void;
   handleLineToggle: (e: any, lineNumber: number) => void;
   isLineSelected: (lineNumber: number) => boolean;
   isStartOfSelection: (lineNumber: number) => boolean;
@@ -33,6 +33,10 @@ function useLineSelection(): useLineSelectionResult {
     }
   };
 
+  const clearLineSelection = () => {
+    setSelectedLines({ start: undefined, end: undefined });
+  };
+
   const isLineSelected = (lineNumber: number) => {
     const { start, end } = selectedLines;
 
@@ -51,7 +55,7 @@ function useLineSelection(): useLineSelectionResult {
 
   return {
     selectedLines,
-    setSelectedLines,
+    clearLineSelection,
     handleLineToggle,
     isLineSelected,
     isStartOfSelection,

--- a/client/src/components/game/Game.tsx
+++ b/client/src/components/game/Game.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useState } from "react";
+import { useCallback, useContext, useState, useEffect } from "react";
 
 import { useHistory } from "react-router-dom";
 import Notification, {
@@ -10,12 +10,15 @@ import Notification, {
 import Editor from "../editor";
 import toast from "react-hot-toast";
 import "./Game.css";
-import { AddComment, Lines } from "../../Interface";
+import { AddComment } from "../../Interface";
 import CommentSider from "../commentSider";
 import DisconnectionModal from "./disconnection/DisconnectionModal";
 import useGameConnection from "./hooks/gameConnection/UseGameConnection";
 import Lobby from "./lobby/Lobby";
 import UserContext from "../../context/UserContext";
+import CommentHighlightContext, {
+  CommentHighlight,
+} from "../../context/CommentHighlightContext";
 
 function getSessionId(path: string) {
   const pathParts = path.split("/");
@@ -27,7 +30,11 @@ function Game() {
   const sessionId = getSessionId(history.location.pathname);
   const { user } = useContext(UserContext);
   const username = user?.username as string;
-  const [focusLines, setFocusLines] = useState<Lines | undefined>(undefined);
+
+  const [commentHighlight, setCommentHighlight] =
+    useState<CommentHighlight>();
+
+  const dehighlight = () => setCommentHighlight(undefined);
 
   const onAlert = useCallback((alert: string) => {
     toast(alert, SUCCESS as any);
@@ -52,8 +59,6 @@ function Game() {
       "Fetching next chunk",
       toastWithId(LOADING, NotificationDisplay.NEXT_ROUND)
     );
-
-    setFocusLines(undefined);
     actions.pickSourceCode();
   };
 
@@ -82,14 +87,21 @@ function Game() {
         </div>
       </div>
       <div className="mid">
-        <Editor
-          code={source_code}
-          newComments={new_comments}
-          onNewCommentAck={actions.ackNewComment}
-          addComment={addCommentHandler}
-          focusLines={focusLines}
-        />
-        <CommentSider comments={comments} setFocusLines={setFocusLines} />
+        <CommentHighlightContext.Provider
+          value={{
+            commentHighlight,
+            highlightComment: setCommentHighlight,
+            dehighlight,
+          }}
+        >
+          <Editor
+            code={source_code}
+            newComments={new_comments}
+            onNewCommentAck={actions.ackNewComment}
+            addComment={addCommentHandler}
+          />
+          <CommentSider comments={comments}/>
+        </CommentHighlightContext.Provider>
       </div>
       <Notification />
       <DisconnectionModal

--- a/client/src/components/game/hooks/gameConnection/UseGameConnection.tsx
+++ b/client/src/components/game/hooks/gameConnection/UseGameConnection.tsx
@@ -14,7 +14,10 @@ import gameReducer from "../../reducers/GameReducer";
 import config from "../../../../config/Config";
 
 function getWebSocketAddress(sessionId: string) {
-  return `${config.wsUri}/${config.socket.uri.replace(":sessionId", sessionId)}`;
+  return `${config.wsUri}/${config.socket.uri.replace(
+    ":sessionId",
+    sessionId
+  )}`;
 }
 
 function useGameConnection(
@@ -72,7 +75,7 @@ function useGameConnection(
     };
 
     socket.onerror = (ev) => {
-      console.log(`Ran into a WS error: ${ev}`);
+      console.log("Ran into a WS error", ev);
     };
 
     setWs(socket);

--- a/client/src/components/joinForm/JoinForm.tsx
+++ b/client/src/components/joinForm/JoinForm.tsx
@@ -25,7 +25,7 @@ function JoinForm({ sessionId }: JoinFormProps) {
   };
 
   const isSessionIdEmpty = () => {
-    return sessionId.length === 0;
+    return joinData.sessionId.length === 0;
   };
   return (
     <>

--- a/client/src/context/CommentHighlightContext.ts
+++ b/client/src/context/CommentHighlightContext.ts
@@ -1,0 +1,19 @@
+import React from "react";
+import { Comment } from "../Interface";
+
+export interface CommentHighlight {
+  comment: Comment;
+}
+
+interface CommentHighlightState {
+  commentHighlight?: CommentHighlight;
+  highlightComment: (commentHighlight: CommentHighlight) => void;
+  dehighlight: () => void;
+}
+
+const CommentHighlightContext = React.createContext<CommentHighlightState>({
+  highlightComment: (_) => {},
+  dehighlight: () => {},
+});
+
+export default CommentHighlightContext;


### PR DESCRIPTION
1. Started on #58: changed the highlight color of the selected comment from the line selection color; implemented comment deselection as updated in the linked issue. Fixed #58 
2. Fixed #62.
3. Implemented lazy scrolling in Editor. The Editor will now only scroll the minimum amount (with some padding) to make visible the region of the selected comment to the viewer.
4. Fixed a minor bug where the `Join` button on the home screen was never enabled.

Previous Editor UI/UX:
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2U4ZDFkODU5Y2E2MjJjMmQ2ZjE5ZGY2MjEyNTZmYTQyNTA0ZmI4NyZjdD1n/0a25t37BgtHauV34KK/giphy.gif)

New Editor Lazy Scrolling:
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNTU5ZDcxZThlYWUxODI0OGM2OGIyMWQxMDVhMDNjYmRlMmU1NzM1OSZjdD1n/flr5dofv9Ngb98Rxqq/giphy.gif)

Line Selection & Comment Selection Interplay:
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzA1NTIxNGE4MmIwNjE4OTUyZjEwOTU0Njg1MTI1MDNiMjEzMzg2ZiZjdD1n/wsHQDxq4NQL70JsN2m/giphy.gif)

Comment Selection & Deselection:
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZjcwNzE5Y2ZmODFkMDJhYzE2MTQ2ODdkOGExMjU3OTNlOTk2ZTdmNSZjdD1n/xCwiEnksWxcIQQMz7E/giphy.gif)


Todo:
- Create a `canInteract` prop for the Editor where comment creation, line selection, and comment selection are only enabled if the prop is true. At the moment, one can create comments on the `lobbyChunk` #68 .
- ~~Figure out how to further distinguish the selected comment from the unselected comments in `CommentSider`. At the moment, only a box-shadow appears around the selected comment. I couldn't figure out how to make a `Comment` "jut out" as described in the proposed solution for Issue 2 in #58. I am curious if you have any opinions on how to "further distinguish" the selected comment~~. 
