### PR TITLE
Run API and web app in the background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ venv/
 package-lock.json
 *.pem
 *.log
-*.pem
 __pycache__/
 .vscode/
 *-venv
+*.out

--- a/run.sh
+++ b/run.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/bash
 run_api(){
     cd ./api;
-    python3.10 main.py
+    nohup python3.10 main.py&
 }
 
 run_web(){
     cd ./client;
-    npx serve build > website.log
+    nohup npx serve build > website.log&
 }
 
-source ~/.nvm/nvm.sh
+kill_existing_runs(){
+    # kills any existing python or npx server processes
+    kill -9 $(ps aux | grep -i -e "python3.10 main.py" -e "npm exec serve build" | grep -v "grep" | awk '{print $2}')
+}
+
+kill_existing_runs
 run_api & run_web


### PR DESCRIPTION
Uses `nohup` to run API and Web App in the background via `run.sh`. Thus, even when the terminal is closed on EC2, these processes will not be terminated.

[nohup usage](https://www.howtogeek.com/804823/nohup-command-linux/)