### PR TITLE
Redirect to login page if `401` on client

### DIFF
--- a/client/src/components/makeForm/MakeForm.tsx
+++ b/client/src/components/makeForm/MakeForm.tsx
@@ -1,5 +1,6 @@
 import toast from "react-hot-toast";
 import { useHistory } from "react-router-dom";
+import { StatusCodes } from "http-status-codes";
 import routes_, { redirectToLoginUrl } from "../../constants/Route";
 import Api from "../../services/HttpApi";
 import { SUCCESS, LOADING, ERROR } from "../notifications/Notification";
@@ -22,7 +23,7 @@ function MakeForm() {
         toast.dismiss(loadingToast);
 
         const { response } = error;
-        if (response.status === 401) {
+        if (response.status === StatusCodes.UNAUTHORIZED) {
           redirectToLoginUrl();
         }
 

--- a/client/src/components/makeForm/MakeForm.tsx
+++ b/client/src/components/makeForm/MakeForm.tsx
@@ -1,6 +1,6 @@
 import toast from "react-hot-toast";
 import { useHistory } from "react-router-dom";
-import routes_ from "../../constants/Route";
+import routes_, { redirectToLoginUrl } from "../../constants/Route";
 import Api from "../../services/HttpApi";
 import { SUCCESS, LOADING, ERROR } from "../notifications/Notification";
 
@@ -20,6 +20,12 @@ function MakeForm() {
       })
       .catch((error) => {
         toast.dismiss(loadingToast);
+
+        const { response } = error;
+        if (response.status === 401) {
+          redirectToLoginUrl();
+        }
+
         toast(
           `Failed to create session with error: ${error.message}`,
           ERROR as any

--- a/client/src/components/navbar/Feedback.tsx
+++ b/client/src/components/navbar/Feedback.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import "./Feedback.css";
 import Api from "../../services/HttpApi";
+import { redirectToLoginUrl } from "../../constants/Route";
 
 interface FeedbackProps {
   onCancel: () => void;
@@ -30,6 +31,12 @@ function Feedback({ onCancel, postSubmit }: FeedbackProps) {
         postSubmit();
       })
       .catch((error) => {
+
+        const { response } = error;
+        if (response.status === 401) {
+          redirectToLoginUrl();
+        }
+
         setStatus(FeedbackStatus.ERROR);
       });
   };

--- a/client/src/components/navbar/Feedback.tsx
+++ b/client/src/components/navbar/Feedback.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { StatusCodes } from "http-status-codes";
 import "./Feedback.css";
 import Api from "../../services/HttpApi";
 import { redirectToLoginUrl } from "../../constants/Route";
@@ -33,7 +34,7 @@ function Feedback({ onCancel, postSubmit }: FeedbackProps) {
       .catch((error) => {
 
         const { response } = error;
-        if (response.status === 401) {
+        if (response.status === StatusCodes.UNAUTHORIZED) {
           redirectToLoginUrl();
         }
 

--- a/client/src/constants/Route.ts
+++ b/client/src/constants/Route.ts
@@ -1,3 +1,5 @@
+import config from "../config";
+
 export const baseRoutes_ = {
     root: "/",
     game: "/game/:sessionId"
@@ -8,6 +10,8 @@ const routes_ = {
     game: (sessionId: string) => baseRoutes_.game.replace(":sessionId", sessionId)
 };
 
-
+export const redirectToLoginUrl = () => {
+    window.location.replace(`${config.baseUri}/${config.login.uri}`);
+}
 
 export default routes_;


### PR DESCRIPTION
does ^

I don't think we need to check for 401 when we initially try to make a ws connection because the game page itself wouldn't load if the user context is not available. See here.

https://github.com/rohanshiva/gitgame/blob/a2647bab80dc3692ca3e0915b65f55b4a86d7fbe/client/src/routers/Router.tsx#L12-L16 