### PR TITLE
Cleaned up Github OAuth

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -1,6 +1,7 @@
 import logging
+from enum import Enum
 from httpx import AsyncClient
-from fastapi import APIRouter, status, HTTPException, Depends
+from fastapi import APIRouter, status, Depends
 from fastapi.responses import RedirectResponse
 from urllib.parse import urlencode, urlparse
 from deps import get_gh_oauth_store
@@ -20,15 +21,37 @@ from services.github_oauth_store import GithubOauthStore, GithubOauthRecord
 from services.auth import Auth
 from uuid import uuid4
 
+
+class GithubOauthError(str, Enum):
+    ACCESS_DENIED = "access_denied"
+
+
+class RedirectionToLoginReason(int, Enum):
+    UNEXPECTED_AUTH_FAILURE = 0
+    USER_DENIED_GITHUB_AUTH = 1
+    COOKIE_EXPIRATION = 2
+
+
 router = APIRouter(prefix="/auth", tags=["Auth"])
-logger = logging.getLogger()
+LOGGER = logging.getLogger()
 
 
-def build_protected_response(url: str, token: str):
+def redirect_with_token(token: str, referrer: str | None = None):
+    url = CLIENT_URL
+    if referrer is not None:
+        url = f"{CLIENT_URL}{referrer}"
     response = RedirectResponse(url)
     domain = urlparse(url).hostname
     response.set_cookie(key="token", value=token, httponly=True, domain=domain)
     return response
+
+
+def redirect_to_login(reason: RedirectionToLoginReason, referrer: str | None = None):
+    # CLIENT_URL is assumed to be the login url as well
+    params = {"redirection_reason": int(reason)}
+    if referrer:
+        params["referrer"] = referrer
+    return RedirectResponse(f"{CLIENT_URL}?{urlencode(params)}")
 
 
 @router.get("/login", status_code=status.HTTP_307_TEMPORARY_REDIRECT)
@@ -44,15 +67,35 @@ async def login(
 
 @router.get("/gh")
 async def authenticate_gh_user(
-    code: str, state: str, oauth_store: GithubOauthStore = Depends(get_gh_oauth_store)
+    state: str,
+    code: str | None = None,
+    error: str | None = None,
+    oauth_store: GithubOauthStore = Depends(get_gh_oauth_store),
 ):
     if not oauth_store.has(state):
-        # The state doesn't exist on our end, so we will have the client retry the authentication process.
+        # Unexpected code branch. The state doesn't exist on our end, so we will have the client retry the authentication process.
         # https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#web-application-flow
-        return RedirectResponse(CLIENT_URL)
+        return redirect_to_login(RedirectionToLoginReason.UNEXPECTED_AUTH_FAILURE)
+
+    oauth_record = oauth_store.pop(state)
+    if error is not None:
+        if GithubOauthError.ACCESS_DENIED == error:
+            return redirect_to_login(
+                RedirectionToLoginReason.USER_DENIED_GITHUB_AUTH,
+                oauth_record["referrer"],
+            )
+        else:
+            # todo: track metrics around auth fails
+            LOGGER.error(
+                f"Github OAuth triggered redirect with an unexpected error: {error}"
+            )
+            return redirect_to_login(
+                RedirectionToLoginReason.UNEXPECTED_AUTH_FAILURE,
+                oauth_record["referrer"],
+            )
 
     async with AsyncClient() as client:
-        params = {
+        payload = {
             "client_id": GITHUB_CLIENT_ID,
             "client_secret": GITHUB_CLIENT_SECRET,
             "code": code,
@@ -60,41 +103,30 @@ async def authenticate_gh_user(
 
         response = await client.post(
             GITHUB_ACCESS_TOKEN_ENDPOINT,
-            json=params,
+            json=payload,
             headers={"Accept": "application/json"},
         )
 
-        if response.status_code != status.HTTP_200_OK:
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-        json = response.json()
-
-        if "error" in json and json["error"] == "bad_verification_code":
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid code. Try again here '/auth/login' ",
+        if response.status_code != status.HTTP_200_OK or "error" in response.json():
+            LOGGER.error(
+                f"Github Access Token Endpoint resulted in an error (status = {response.status_code}): {response.text}"
+            )
+            return redirect_to_login(
+                RedirectionToLoginReason.UNEXPECTED_AUTH_FAILURE,
+                oauth_record["referrer"],
             )
 
-        access_token = json["access_token"]
+        access_token = response.json()["access_token"]
         gh_client = GithubClient(access_token)
 
         try:
             user = await gh_client.get_user()
             username = user["username"]
             token = Auth.encode(username)
-            oauth_record = oauth_store.get(state)
-            oauth_store.delete(state)
-            target = CLIENT_URL
-            if oauth_record["referrer"] is not None:
-                target = f"{CLIENT_URL}{oauth_record['referrer']}"
-            return build_protected_response(target, token)
-        except GithubUserNotFound:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Account/User not found. Try again here `/auth/login`",
-            )
-        except GithubUserLoadingError:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Something unexpected went wrong. Try again here `/auth/login`",
+            return redirect_with_token(token, oauth_record["referrer"])
+        except GithubUserNotFound | GithubUserLoadingError:
+            LOGGER.error("Github API failed to retrieve the user")
+            return redirect_to_login(
+                RedirectionToLoginReason.UNEXPECTED_AUTH_FAILURE,
+                oauth_record["referrer"],
             )

--- a/api/routes/user.py
+++ b/api/routes/user.py
@@ -3,7 +3,7 @@ import logging
 from config import DISABLE_AUTH
 from services.auth import Auth, Context
 from fastapi import APIRouter, Depends, HTTPException, status
-from .auth import build_protected_response
+from .auth import redirect_with_token
 from deps import get_context
 
 router = APIRouter(prefix="/user", tags=["User"])
@@ -31,4 +31,4 @@ async def impersonate(username: str):
         )
 
     token = Auth.encode(username)
-    return build_protected_response("http://127.0.0.1:3000/", token)
+    return redirect_with_token(token)

--- a/api/services/auth.py
+++ b/api/services/auth.py
@@ -34,9 +34,7 @@ class Auth:
     def decode(token: str):
         try:
             payload = jwt.decode(token, AUTH_SECRET, algorithms=["HS256"])
-
             res = Context(username=payload["sub"], is_expiring=False)
-
             exp = datetime.fromtimestamp(payload["exp"], timezone.utc)
             now = datetime.now(timezone.utc)
             delta = exp - now

--- a/api/services/github_client.py
+++ b/api/services/github_client.py
@@ -63,7 +63,8 @@ def log_gh_api_response(response: Response):
     )
 
 
-MAX_FILE_SIZE = 15000 # in bytes
+MAX_FILE_SIZE = 15000  # in bytes
+
 
 class GithubClient:
     def __init__(self, access_token: str):

--- a/api/services/github_oauth_store.py
+++ b/api/services/github_oauth_store.py
@@ -19,14 +19,13 @@ class GithubOauthStore:
     def has(self, key: str):
         return key in self.__store
 
-    def get(self, key: str) -> GithubOauthRecord:
-        return self.__store[key]
+    def pop(self, key: str) -> GithubOauthRecord:
+        record = self.__store[key]
+        del self.__store[key]
+        return record
 
     def put(self, key: str, record: GithubOauthRecord):
         self.__store[key] = record
-
-    def delete(self, key: str):
-        del self.__store[key]
 
     @classmethod
     def instance(cls):

--- a/client/src/Interface.ts
+++ b/client/src/Interface.ts
@@ -120,3 +120,9 @@ export interface GameState {
 export interface User {
   username: string;
 }
+
+export enum RedirectionToLoginReason {
+  UNEXPECTED_AUTH_FAILURE = 0,
+  USER_DENIED_GITHUB_AUTH = 1,
+  COOKIE_EXPIRATION = 2,
+}

--- a/client/src/components/makeForm/MakeForm.tsx
+++ b/client/src/components/makeForm/MakeForm.tsx
@@ -4,6 +4,7 @@ import { StatusCodes } from "http-status-codes";
 import routes_, { redirectToLoginUrl } from "../../constants/Route";
 import Api from "../../services/HttpApi";
 import { SUCCESS, LOADING, ERROR } from "../notifications/Notification";
+import { RedirectionToLoginReason } from "../../Interface";
 
 function MakeForm() {
   const history = useHistory();
@@ -23,7 +24,10 @@ function MakeForm() {
         toast.dismiss(loadingToast);
         const { response } = error;
         if (response.status === StatusCodes.UNAUTHORIZED) {
-          redirectToLoginUrl({ didCookieExpirePostAuth: true });
+          redirectToLoginUrl({
+            redirectionToLoginReason:
+              RedirectionToLoginReason.COOKIE_EXPIRATION,
+          });
         } else {
           toast(
             `Failed to create session with error: ${error.message}`,

--- a/client/src/components/navbar/Feedback.tsx
+++ b/client/src/components/navbar/Feedback.tsx
@@ -4,6 +4,7 @@ import "./Feedback.css";
 import Api from "../../services/HttpApi";
 import { redirectToLoginUrl } from "../../constants/Route";
 import { useLocation } from "react-router-dom";
+import { RedirectionToLoginReason } from "../../Interface";
 
 interface FeedbackProps {
   onCancel: () => void;
@@ -38,7 +39,8 @@ function Feedback({ onCancel, postSubmit }: FeedbackProps) {
         if (response.status === StatusCodes.UNAUTHORIZED) {
           redirectToLoginUrl({
             referrer: pathname,
-            didCookieExpirePostAuth: true,
+            redirectionToLoginReason:
+              RedirectionToLoginReason.COOKIE_EXPIRATION,
           });
         }
 

--- a/client/src/constants/Route.ts
+++ b/client/src/constants/Route.ts
@@ -1,3 +1,5 @@
+import { RedirectionToLoginReason } from "../Interface";
+
 export const baseRoutes_ = {
   root: "/",
   game: "/game/:sessionId",
@@ -11,7 +13,7 @@ const routes_ = {
 
 export interface LoginParams {
   referrer?: string;
-  didCookieExpirePostAuth?: boolean;
+  redirectionToLoginReason?: RedirectionToLoginReason;
 }
 
 export function redirectToLoginUrl(params: LoginParams) {
@@ -20,11 +22,14 @@ export function redirectToLoginUrl(params: LoginParams) {
 
 export function constructRedirectToLoginUrl({
   referrer,
-  didCookieExpirePostAuth,
+  redirectionToLoginReason,
 }: LoginParams) {
   const queryParams = new URLSearchParams();
-  if (didCookieExpirePostAuth) {
-    queryParams.append("didCookieExpirePostAuth", "true");
+  if (redirectionToLoginReason) {
+    queryParams.append(
+      "redirection_reason",
+      redirectionToLoginReason.toString()
+    );
   }
   if (referrer) {
     queryParams.append("referrer", referrer);


### PR DESCRIPTION
There existed edge cases in Github OAuth that were not handled prior. For instance, if a player denies authorizing Gitgame, Github will respond with an error not caught prior.

* Captures any error within `/auth/gh/` and redirects the client to the login, preserving the `referrer` query param.
* Renames `didCookieExpirePostAuth` to `redirectionToLoginReason` to elicit more general redirection reasons such as an unexpected auth failure or user denying authorization.

Before:

https://github.com/rohanshiva/gitgame/assets/41026856/acbe2fe1-7f2d-41de-9276-5e494bb39020

After:

https://github.com/rohanshiva/gitgame/assets/41026856/a715a5a2-ba16-4014-a2e5-bed069bae995
