### PR TITLE
Reorganize comments on sider

### DIFF
--- a/client/src/components/commentSider/CommentSider.css
+++ b/client/src/components/commentSider/CommentSider.css
@@ -1,34 +1,14 @@
-.comments-container-header {
-  font-weight: 500;
-}
-
-.filters {
+.comments-container-header-title {
   display: flex;
   flex-direction: row;
+  justify-content: space-evenly;
+  padding-top: 0.4rem;
+  padding-bottom: 0.4rem;
   border: 0.1rem solid var(--border);
   border-radius: 0.2rem;
-  padding: 0.2rem;
-  font-size: 1rem;
-  align-items: center;
-  width: 100%;
-}
-
-.filter {
-  cursor: pointer;
-  padding: 0.4rem 1rem;
-  width: 100%;
   text-align: center;
-}
-
-.selected-filter {
-  border-radius: 0.2rem;
-  background-color: var(--secondary);
-}
-
-.emoji-reactions {
-  border: 0.1rem solid var(--border);
-  border-radius: 0.8rem;
-  padding: 0.1rem 0.5rem;
+  font-weight: 500;
+  width: 100%;
 }
 
 abbr {
@@ -73,7 +53,6 @@ abbr {
 }
 
 .player-comment {
-  position: relative;
   border: 0.1rem solid var(--border);
   border-radius: 0.4rem;
   padding: 0.4rem;
@@ -83,7 +62,7 @@ abbr {
   cursor: pointer;
   box-shadow: none;
   transition-duration: 150ms;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Inter", sans-serif;
 }
 
 .player-comment:hover {
@@ -98,9 +77,16 @@ abbr {
 .player-comment-header {
   display: flex;
   flex-direction: row;
-  gap: 0.2rem;
   align-items: center;
   font-weight: bold;
+  justify-content: space-between;
+}
+
+.player-comment-author {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.4rem;
 }
 
 .player-comment-avatar {
@@ -112,5 +98,22 @@ abbr {
 
 .player-comment-content {
   text-overflow: ellipsis;
-  font-size: 0.9rem;
+}
+
+.player-comment-info {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.player-comment-emoji-tag {
+  border: 0.1rem solid var(--border);
+  border-radius: 0.8rem;
+  padding: 0.1rem 0.5rem;
+  font-family: "Space Grotesk", sans-serif;
+}
+
+.player-comment-line-tag {
+  font-weight: normal;
 }

--- a/client/src/components/commentSider/CommentSider.tsx
+++ b/client/src/components/commentSider/CommentSider.tsx
@@ -1,7 +1,6 @@
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import {
   Comment as IComment,
-  CommentType,
   commentTypeToEmoji,
 } from "../../Interface";
 import "./CommentSider.css";
@@ -13,16 +12,13 @@ interface CommentProps {
 }
 
 function Comment({ comment }: CommentProps) {
-  const { id, author, content } = comment;
+  const { id, author, content, type, line_start: lineStart, line_end: lineEnd } = comment;
   const { commentHighlight, highlightComment } = useContext(
     CommentHighlightContext
   );
   const profileBorderColor = getColor(author.username);
 
-  let className = "player-comment";
-  if (commentHighlight && commentHighlight.comment.id === id) {
-    className += " player-comment-selected";
-  }
+  const className = `player-comment ${(commentHighlight && commentHighlight.comment.id === id) && "player-comment-selected"}`
 
   const onCommentClick = (ev: React.MouseEvent) => {
     ev.stopPropagation();
@@ -34,13 +30,24 @@ function Comment({ comment }: CommentProps) {
   return (
     <div className={className} onClick={onCommentClick}>
       <div className="player-comment-header">
-        <img
-          alt={`https://github.com/${author.username}`}
-          className="player-comment-avatar"
-          style={{ borderColor: profileBorderColor }}
-          src={author.profile_url}
-        />
-        <div>{author.username}</div>
+        <div className="player-comment-author">
+          <img
+            alt={`https://github.com/${author.username}`}
+            className="player-comment-avatar"
+            style={{ borderColor: profileBorderColor }}
+            src={author.profile_url}
+          />
+          <div>{author.username}</div>
+        </div>
+        <div className="player-comment-info">
+          <div className="player-comment-line-tag">
+            {`L${lineStart}-L${lineEnd}`}
+          </div>
+          <div className="player-comment-emoji-tag">
+            {commentTypeToEmoji(type)}
+          </div>
+        </div>
+
       </div>
       <div className="player-comment-content">{content}</div>
     </div>
@@ -49,74 +56,19 @@ function Comment({ comment }: CommentProps) {
 
 interface CommentListProps {
   comments: IComment[];
-  commentType: CommentType;
 }
 
-function CommentList({ comments, commentType }: CommentListProps) {
-  const groupCommentsByLines = () => {
-    const map = new Map<string, IComment[]>();
-    for (const comment of comments) {
-      const { line_start, line_end } = comment;
-      const key = `${line_start}-${line_end}`;
-      if (!map.has(key)) {
-        map.set(key, []);
-      }
-      map.set(key, (map.get(key) as IComment[]).concat(comment));
-    }
-
-    const groupedComments = Array.from(map.values()).map((comments) => {
-      const uniqueAuthors = Array.from(
-        new Set(comments.map(({ author }) => author.username))
-      );
-      uniqueAuthors.sort();
-
-      return {
-        comments,
-        lines: {
-          start: comments[0].line_start,
-          end: comments[0].line_end,
-        },
-        authors: uniqueAuthors,
-      };
-    });
-
-    groupedComments.sort((a, b) => {
-      if (a.lines.start < b.lines.start) {
-        return -1;
-      }
-      if (b.lines.start < a.lines.start) {
-        return 1;
-      }
-      if (a.lines.end < b.lines.end) {
-        return -1;
-      }
-      return 1;
-    });
-
-    return groupedComments;
-  };
+function CommentList({ comments }: CommentListProps) {
 
   return (
     <div className="comments-container-content">
-      {groupCommentsByLines().map(({ lines, comments, authors }, index) => {
-        return (
-          <div className="comments-section" key={index}>
-            <div className="comments-section-header">
-              <span>{`L${lines.start + 1}-L${lines.end + 1}`}</span>
-              <abbr title={authors.join(", ")}>
-                <span className="emoji-reactions">
-                  {commentTypeToEmoji(commentType)} {comments.length}
-                </span>
-              </abbr>
-            </div>
-            <div className="comments-section-content">
-              {comments.map((comment) => (
-                <Comment key={comment.id} comment={comment} />
-              ))}
-            </div>
-          </div>
-        );
-      })}
+      <div className="comments-section">
+        <div className="comments-section-content">
+          {comments.map((comment) => (
+            <Comment key={comment.id} comment={comment} />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
@@ -126,23 +78,18 @@ interface CommentSiderProps {
 }
 
 function CommentSider({ comments }: CommentSiderProps) {
-  const [filter, setFilter] = useState<CommentType>(CommentType.POOP);
   const { dehighlight } = useContext(CommentHighlightContext);
 
   const getCommentsDisplay = () => {
-    if (hasCommentsForType(filter)) {
-      const filteredComments = comments.filter(({ type }) => type === filter);
-      return <CommentList comments={filteredComments} commentType={filter} />;
+    if (comments.length) {
+      return <CommentList comments={comments} />;
     } else {
       return (
         <div>
-          No {commentTypeToEmoji(filter)} comments yet! Click <kbd>Help</kbd> for instructions.
+          No comments yet! Click <kbd>Help</kbd> for instructions.
         </div>
       );
     }
-  };
-  const hasCommentsForType = (commentType: CommentType) => {
-    return comments.filter(({ type }) => type === commentType).length > 0;
   };
 
   return (
@@ -151,33 +98,10 @@ function CommentSider({ comments }: CommentSiderProps) {
         className="comments-container-header"
         onClick={(ev) => ev.stopPropagation()}
       >
-        <div className="filters">
-          <div
-            className={
-              filter === CommentType.POOP
-                ? "filter selected-filter"
-                : "filter"
-            }
-            onClick={() => {
-              setFilter(CommentType.POOP);
-            }}
-          >
-            Roasts
-            💩
-          </div>
-          <div
-            className={
-              filter === CommentType.DIAMOND
-                ? "filter selected-filter"
-                : "filter"
-            }
-            onClick={() => {
-              setFilter(CommentType.DIAMOND);
-            }}
-          >
-            Kudos
-            💎
-          </div>
+        <div className="comments-container-header-title">
+          <span>
+            Kudos 💎 / Roasts 💩
+          </span>
         </div>
       </div>
       {getCommentsDisplay()}

--- a/client/src/components/commentSider/CommentSider.tsx
+++ b/client/src/components/commentSider/CommentSider.tsx
@@ -18,7 +18,8 @@ function Comment({ comment }: CommentProps) {
   );
   const profileBorderColor = getColor(author.username);
 
-  const className = `player-comment ${(commentHighlight && commentHighlight.comment.id === id) && "player-comment-selected"}`
+  const isHighlighted = commentHighlight && commentHighlight.comment.id === id;
+  const className = `player-comment ${isHighlighted && "player-comment-selected"}`
 
   const onCommentClick = (ev: React.MouseEvent) => {
     ev.stopPropagation();

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -155,7 +155,7 @@ video {
   justify-content: flex-end;
   gap: 0.4rem;
   border-top: 0.1rem solid var(--border);
-  padding: 0.2rem 0.4rem;
+  padding: 0.6rem 0.4rem;
 }
 
 .context-menu-button {


### PR DESCRIPTION
Remove comment type filter on sider. Comments are organized from oldest to latest (oldest on top). 

![image](https://github.com/rohanshiva/gitgame/assets/20916697/09a655d8-6dcc-4a8b-ac38-f3bb576cc236)

![image](https://github.com/rohanshiva/gitgame/assets/20916697/0a77f1bf-8969-4508-9712-ec9e58e590ac)

Will work on the toasts based on comment type in another PR. 