### PR TITLE
Check if game has terminated on player join

### DIFF
--- a/api/routes/ws.py
+++ b/api/routes/ws.py
@@ -203,13 +203,12 @@ async def on_join(ctx: WSEventContext):
             )
 
     ctx.connection_manager.add(ctx.connection)
-    await broadcast(
-        ctx,
-        await get_lobby(ctx.session_id),
-        get_alert(f"{ctx.player_name} has joined"),
-        await get_code(ctx.session_id),
-        await get_comments(ctx.session_id),
-    )
+    lobby = await get_lobby(ctx.session_id)
+    alert = get_alert(f"{ctx.player_name} has joined")
+    if await Crud.is_terminated(ctx.session_id):
+        await broadcast(ctx, lobby, alert, GameFinishedResponse())
+    else:
+        await broadcast(ctx, lobby, alert, await get_code(ctx.session_id), await get_comments(ctx.session_id))
 
 
 @instrument


### PR DESCRIPTION
Before, if a player joins a terminated game, the newly joined player would stay in the lobby and would be unaware that the game has been completed.

Before:

https://github.com/rohanshiva/gitgame/assets/41026856/3449ce7d-f615-46bd-9f69-304785700605

Now, when the player joins, a check is made to see if the game has terminated. If it has, then the `GameFinishedResponse` will be returned, indicating that the game has terminated.


https://github.com/rohanshiva/gitgame/assets/41026856/31f38fa7-05cf-49ae-978b-ad23d59c5a3c

