### PR TITLE
Fix demo video black bg on large screens

### DIFF
--- a/client/src/components/home/Home.css
+++ b/client/src/components/home/Home.css
@@ -61,10 +61,11 @@ input[type="submit"]:hover {
 }
 
 .home-right {
-  background-color: var(--primary);
   border-radius: 1rem;
-  width: 100%;
   height: 512px;
+  width: 100%;
   z-index: -1;
+  display: flex;
+  justify-content: flex-end;
 }
 


### PR DESCRIPTION
Before recording the demo video, we set the bg color of the demo video area to be `primary` - just as a placeholder. 

We don't need it anymore because we have a demo video. 

Before
![image](https://github.com/rohanshiva/gitgame/assets/20916697/d0141c0f-2c28-4176-bb7b-bbe5d0a81263)

After 
![image](https://github.com/rohanshiva/gitgame/assets/20916697/6a63451a-bc8c-4129-99ec-0cb1dccae8dc)
